### PR TITLE
Fix an issue with cc at the start of a line.

### DIFF
--- a/plugin/paredit.vim
+++ b/plugin/paredit.vim
@@ -357,7 +357,6 @@ endfunction
 
 " General change operator handling
 function! PareditChange( type, ... )
-    let startcol = col('.')
     let ve_save = &virtualedit
     set virtualedit=all
     call PareditOpfunc( 'c', a:type, a:0 )
@@ -370,7 +369,7 @@ function! PareditChange( type, ... )
         endif
         execute "call setline( v:lnum, repeat( ' ', " . expr . " ) )"
         normal! $l
-    elseif startcol > 1
+    else
         normal! l
     endif
     startinsert


### PR DESCRIPTION
Hi @kovisoft, 

I wonder what's the purpose of `startcol`'s branching logic? Because I find it doing wrong `cc` behavior if I do `cc` at the start of a line (at col 1, that is).

e.g.

``` clojure
(let [a b]
  (print a)
| (print b))
```

If I press `cc` where `|`, I get

``` clojure
(let [a b]
  (print a)
 | )
```

However, if I remove the `startcol`'s logic, everything seems to be fine.
Also, this is confirmed in both Vim 7.4.x and Vim 7.2.x. I don't have Vim 7.3.x so I can't tell how it behaves on it.
