### PR TITLE
Fix possible cursor move problem caused by &indentexpr.

### DIFF
--- a/plugin/paredit.vim
+++ b/plugin/paredit.vim
@@ -363,17 +363,13 @@ function! PareditChange( type, ... )
     call PareditOpfunc( 'c', a:type, a:0 )
     if len(getline('.')) == 0
         let v:lnum = line('.')
-        let cnum = col('.')
         let expr = &indentexpr
         if expr == ''
             " No special 'indentexpr', call default lisp indent
             let expr = 'lispindent(v:lnum)'
         endif
         execute "call setline( v:lnum, repeat( ' ', " . expr . " ) )"
-        " Need to restore cursor because indentexpr functions may
-        " move the cursor.
-        call cursor(v:lnum, cnum)
-        normal! $l
+        call cursor(v:lnum, len(getline(v:lnum))+1)
     elseif startcol > 1
         normal! l
     endif


### PR DESCRIPTION
Calling &indentexpr may cause undesirable cursor move, in fact, it is causing problems calling vim-clojure-static GetClojureIndent(), this function also moves the cursor. So it's better to manually restore the cursor to prevent this and similar problems.
