### PR TITLE
Use <Leader> instead of mapleader

### DIFF
--- a/plugin/paredit.vim
+++ b/plugin/paredit.vim
@@ -48,7 +48,7 @@ endif
 " Custom <Leader> for the Paredit plugin
 if !exists( 'g:paredit_leader' )
     if exists( 'mapleader' )
-        let g:paredit_leader = mapleader
+        let g:paredit_leader = '<leader>'
     else
         let g:paredit_leader = ','
     endif


### PR DESCRIPTION
This fixes the problem with space-leader (`let mapleader = ' '`) where
"shortmaps" are defined even when `g:paredit_shortmaps` is not set.
