### PR TITLE
Unescaped square brackets in balance detection

### DIFF
--- a/plugin/paredit.vim
+++ b/plugin/paredit.vim
@@ -583,10 +583,10 @@ function! s:IsBalanced()
     endif
 
     if &ft =~ s:fts_balancing_all_brackets
-        if line[c-1] == '\['
+        if line[c-1] == '['
             let b1 = searchpair( '\[', '', '\]', 'brnmWc', s:skip_sc, matchb )
             let b2 = searchpair( '\[', '', '\]',  'rnmW' , s:skip_sc, matchf )
-        elseif line[c-1] == '\]'
+        elseif line[c-1] == ']'
             let b1 = searchpair( '\[', '', '\]', 'brnmW' , s:skip_sc, matchb )
             let b2 = searchpair( '\[', '', '\]',  'rnmWc', s:skip_sc, matchf )
         else


### PR DESCRIPTION
Hey, Tamas! Thanks for writing paredit.vim; it's a much appreciated addition to my environment.

I didn't perceive any deficiencies with the old method, but the new balance detection code certainly seems more thorough, so I'm happy with the change. Alas, it seems square brackets are no longer handled correctly.

Testing with `vim -u NONE foo.clj` and paredit.vim in `~/.vim/plugins`, I observe the following behavior:

```
[: [_]    good so far
[: [[_]   no second closing bracket   
]: [[]_]  cursor misplaced
]: [[]]_] stray immortal bracket
```

I can't say whether this is something to do with my setup or not, but thankfully the fix—for me, anyhow—was as simple as not escaping the brackets in the comparison with `line[c-1]`. I hope this fix is applicable for you and others as well.
