### PR TITLE
Recognize comments in Janet files

### DIFF
--- a/plugin/paredit.vim
+++ b/plugin/paredit.vim
@@ -86,6 +86,9 @@ let s:fts_multiline_comment      = '.*\(scheme\|racket\).*'
 " Filetypes with datum comment #;(...)
 let s:fts_datum_comment          = '.*\(scheme\).*'
 
+" Filetypes with hash comment
+let s:fts_hash_comment           = '.*\(janet\).*'
+
 " =====================================================================
 "  General utility functions
 " =====================================================================
@@ -592,7 +595,10 @@ function! s:InsideComment( ... )
         let line = strpart( getline(l), 0, c - 1 )
         let line = substitute( line, '\\"', '', 'g' )
         let line = substitute( line, '"[^"]*"', '', 'g' )
-        if &ft == 'janet' | let comment_char = '#' | else | let comment_char = ';' | end
+        let comment_char = ';'
+        if &ft =~ s:fts_hash_comment
+            let comment_char = '#'
+        endif
         return match( line, comment_char ) >= 0
     endif
     if s:SynIDMatch( 'clojureComment', l, c, 1 )
@@ -749,7 +755,10 @@ function! s:GetMatchedChars( lines, start_in_string, start_in_comment )
                 let matched = strpart( matched, 0, i ) . a:lines[i] . strpart( matched, i+1 )
                 let inside_string = 1
             endif
-            if &ft == 'janet' | let comment_char = '#' | else | let comment_char = ';' | end
+            let comment_char = ';'
+            if &ft =~ s:fts_hash_comment
+                let comment_char = '#'
+            endif
             if a:lines[i] == comment_char
                 let inside_comment = 1
                 if &ft =~ s:fts_datum_comment && i > 0 && a:lines[i-1] == '#'
@@ -1208,7 +1217,10 @@ function! s:EraseFwd( count, startcol )
     let ve_save = &virtualedit
     set virtualedit=all
     let c = a:count
-    if &ft == 'janet' | let comment_char = '#' | else | let comment_char = ';' | end
+    let comment_char = ';'
+    if &ft =~ s:fts_hash_comment
+        let comment_char = '#'
+    endif
     while c > 0
         if line[pos] == '\' && line[pos+1] =~ b:any_matched_char && (pos < 1 || line[pos-1] != '\')
             " Erasing an escaped matched character


### PR DESCRIPTION
Fix issue #47 partly.

Janet uses `#` for comments (Lisp uses `;`).