### PR TITLE
Fix PareditEnter for noselect completeopt

### DIFF
--- a/plugin/paredit.vim
+++ b/plugin/paredit.vim
@@ -1091,7 +1091,7 @@ endfunction
 
 " Handle <Enter> keypress, insert electric return if applicable
 function! PareditEnter()
-    if pumvisible() && &completeopt !~# 'longest\|noinsert\|noselect'
+    if pumvisible()
         " Pressing <CR> in a pop up selects entry.
         return "\<C-Y>"
     else

--- a/plugin/paredit.vim
+++ b/plugin/paredit.vim
@@ -1092,8 +1092,14 @@ endfunction
 " Handle <Enter> keypress, insert electric return if applicable
 function! PareditEnter()
     if pumvisible()
-        " Pressing <CR> in a pop up selects entry.
-        return "\<C-Y>"
+        let lastchar = getline('.')[col('.')-2]
+        if stridx(')]}', lastchar) >= 0
+            " Select entry and add closing bracket (which vim removes)
+            return "\<C-Y>" . lastchar . "\<Left>"
+        else
+            " Pressing <CR> in a pop up selects entry.
+            return "\<C-Y>"
+        endif
     else
         let line = getline( '.' )
         let pos = col( '.' ) - 1


### PR DESCRIPTION
Fix #51.

When return is pressed while the autocompletion popup menu is open, confirm the selected item **or the non-selection** (for completeopt=noselect) in any case.